### PR TITLE
fix yacl config requirement

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
     "minecraft": "~1.19.3-rc.1",
     "java": ">=17",
     "fabric": "*",
-    "yet-another-config-lib": "2.x.x"
+    "yet-another-config-lib": "~2.1.1"
   },
   "breaks": {
     "tooltipfix": "*"


### PR DESCRIPTION
Fixes startup crash on Quilt.
```
Adaptive Tooltips requires version [[2.x.x,2.x.x]] of yet-another-config-lib, which is missing!
Adaptive Tooltips is loaded from C:\Users\*****\MultiMC\instances\Custom\.minecraft\mods\AdaptiveTooltips-1.1.1-fabric-1.19.3.jar
```

Closes #12 