### PR TITLE
Fixed crash on startup due to YACL version issue

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
     "minecraft": "~1.19.3-rc.1",
     "java": ">=17",
     "fabric": "*",
-    "yet-another-config-lib": "~2.1.1"
+    "yet-another-config-lib": ">=2.2.0"
   },
   "breaks": {
     "tooltipfix": "*"


### PR DESCRIPTION
#11 
Today I've compiled mod from sources with latest fix but the issue hadn't disappeared so I fixed it by myself. I tested and everything works. Tested on quilt loader 0.18.1-beta26 and YACL 2.2.0